### PR TITLE
Annotations: Add support for adding & filtering on branch info to UI

### DIFF
--- a/BRANCHES_DASHBOARD.json
+++ b/BRANCHES_DASHBOARD.json
@@ -43,8 +43,8 @@
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,
         "name": "annotations",
-        "query": "SELECT text, title, tagText FROM annotations WHERE $timeFilter",
-        "tagsColumn": "tagText",
+        "query": "SELECT text, title, tagText, branch FROM annotations WHERE $timeFilter AND (\"branch\" =~ /^$branch$/ OR \"branch\" =~ /^$/)",
+        "tagsColumn": "tagText, branch",
         "textColumn": "text",
         "titleColumn": "title",
         "type": "alert"
@@ -319,5 +319,5 @@
   },
   "timezone": "browser",
   "title": "QmlBench Branches",
-  "version": 13
+  "version": 15
 }

--- a/HARDWARE_DASHBOARD.json
+++ b/HARDWARE_DASHBOARD.json
@@ -43,8 +43,8 @@
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,
         "name": "annotations",
-        "query": "SELECT text, title, tagText FROM annotations WHERE $timeFilter",
-        "tagsColumn": "tagText",
+        "query": "SELECT text, title, tagText, branch FROM annotations WHERE $timeFilter AND (\"branch\" =~ /^$branch$/ OR \"branch\" =~ /^$/)",
+        "tagsColumn": "tagText, branch",
         "textColumn": "text",
         "titleColumn": "title",
         "type": "alert"
@@ -318,5 +318,5 @@
   },
   "timezone": "browser",
   "title": "QmlBench Hardware",
-  "version": 13
+  "version": 16
 }

--- a/annotate.py
+++ b/annotate.py
@@ -9,7 +9,7 @@ import json
 HOSTNAME = "10.213.255.45:8086"
 #HOSTNAME = "localhost:8086"
 
-def post_annotation(title, text, tag):
+def post_annotation(title, text, tag, branch):
     # TODO: we could consider splitting tag on , and inserting multiple annotations
     # this is required, unfortunately, as Grafana's InfluxDB source requires that you
     # fetch tags from multiple fields rather than turning a single field into
@@ -17,6 +17,7 @@ def post_annotation(title, text, tag):
     fields = ('title=\"%s\"' % title,
               'text=\"%s\"' % text,
               'tagText=\"%s\"' % tag,
+              'branch=\"%s\"' % branch,
               )
     data = 'annotations %s' % (','.join(fields))
     result = requests.post("http://%s/write?db=qmlbench" % HOSTNAME, data=data.encode('utf-8'))
@@ -29,8 +30,9 @@ if __name__ == "__main__":
     parser.add_argument("--title", help="title of the annotation (e.g. --title=\"qtbase update\")")
     parser.add_argument("--tag", help="a tag for the annotation")
     parser.add_argument("--text", help="text for the annotation")
+    parser.add_argument("--branch", help="the branch the annotation is relevant to (e.g. 5.6, dev")
     args = parser.parse_args(sys.argv[1:])
     print("Adding annotation: " + args.title)
-    post_annotation(args.title, args.text, args.tag)
+    post_annotation(args.title, args.text, args.tag, args.branch)
 
 


### PR DESCRIPTION
Version updates and things like that only make sense for the branch they
happened on. So we don't want to see 5.6 events when looking at dev (for
example).

To fix this, we add a --branch parameter to annotate.py that takes a
string branch field. In the dashboards, we filter on this (allowing an
empty branch to indicate a "global" event), and we mark it as an
additional tag for UI purposes.