### PR TITLE
Improve CoV graph display and report empty points for failed tests

### DIFF
--- a/BRANCHES_DASHBOARD.json
+++ b/BRANCHES_DASHBOARD.json
@@ -279,10 +279,10 @@
             },
             {
               "format": "percentunit",
-              "label": null,
+              "label": "",
               "logBase": 1,
-              "max": null,
-              "min": null,
+              "max": "0.1",
+              "min": "0",
               "show": true
             }
           ]
@@ -394,5 +394,5 @@
   },
   "timezone": "browser",
   "title": "QmlBench Branches",
-  "version": 22
+  "version": 24
 }

--- a/HARDWARE_DASHBOARD.json
+++ b/HARDWARE_DASHBOARD.json
@@ -278,9 +278,9 @@
             },
             {
               "format": "percentunit",
-              "label": null,
+              "label": "",
               "logBase": 1,
-              "max": null,
+              "max": "0.1",
               "min": null,
               "show": true
             }
@@ -393,5 +393,5 @@
   },
   "timezone": "browser",
   "title": "QmlBench Hardware",
-  "version": 20
+  "version": 23
 }


### PR DESCRIPTION
CoV graphs should be obvious, but for the run.py change, quoting the commit message:

    run.py: Add additional debug and fix handling of "bad" runs

    Instead of skipping an empty run completely, report a 0 point. In my
    opinion, this is better as it will give a visual report that something
    is not right.

    While we are here, use the reported CoV rather than generating it again
    in the python runner to ensure there is only one source of values to
    avoid future confusion.