### PR TITLE
Slight tweaks to visualization

### DIFF
--- a/BRANCHES_DASHBOARD.json
+++ b/BRANCHES_DASHBOARD.json
@@ -110,10 +110,13 @@
           "seriesOverrides": [
             {
               "alias": "/CoV.+/",
-              "fill": 0,
               "stack": false,
               "yaxis": 2,
               "zindex": 3
+            },
+            {
+              "alias": "/Result.+/",
+              "fill": 0
             }
           ],
           "span": 6,

--- a/HARDWARE_DASHBOARD.json
+++ b/HARDWARE_DASHBOARD.json
@@ -109,10 +109,13 @@
           "seriesOverrides": [
             {
               "alias": "/CoV.+/",
-              "fill": 0,
               "stack": false,
               "yaxis": 2,
               "zindex": 3
+            },
+            {
+              "alias": "/Result.+/",
+              "fill": 0
             }
           ],
           "span": 6,


### PR DESCRIPTION
Set the CoV to have a line fill, not the regular series.

With a lot of branches visible, the fills start to mess up the dashboard
a bit. Since the CoV are (ideally) at the bottom of the graph anyway,
having them filled is acceptable -- and it will provide a slight visual
indication if a CoV goes above the (10%) limit, above the graph.